### PR TITLE
refactor client to use configurer

### DIFF
--- a/whclient/client.go
+++ b/whclient/client.go
@@ -34,7 +34,8 @@ type Config struct {
 // to be used by the client
 type Configurer func() (Config, error)
 
-// Client ...
+// Client used to connect to a proxy instance and serve content
+// over the proxy. Client implements net.Listener.
 type Client struct {
 	m          sync.Mutex
 	id         string
@@ -50,6 +51,7 @@ type Client struct {
 	acceptErr  net.Error
 }
 
+// New creates a new Client instance.
 func New(configurer Configurer) (*Client, error) {
 	config, err := configurer()
 	if err != nil {
@@ -68,10 +70,14 @@ func New(configurer Configurer) (*Client, error) {
 	return cl, nil
 }
 
+// URL returns the url at which the proxy serves the client's
+// endpoints
 func (c *Client) URL() string {
 	return c.url.Load().(string)
 }
 
+// Accept is used to accept multiplexed streams from the
+// proxy as net.Conn.
 func (c *Client) Accept() (net.Conn, error) {
 	select {
 	case <-c.closed:
@@ -95,6 +101,7 @@ func (c *Client) Accept() (net.Conn, error) {
 	return stream, nil
 }
 
+// Addr returns the net.Addr of the underlying wsmux session
 func (c *Client) Addr() net.Addr {
 	return c.session.Addr()
 }

--- a/whclient/errors.go
+++ b/whclient/errors.go
@@ -5,6 +5,7 @@ type clientError struct {
 	errString string
 	reconnect bool
 	timeout   bool
+	auth      bool
 }
 
 func (c clientError) Error() string {
@@ -36,9 +37,9 @@ var (
 	// ErrClientClosed is returned from an Accept call when the client is closed.
 	ErrClientClosed = clientError{errString: "client closed"}
 
-	// ErrAuthorizerNotProvided is returned from New when an Authorizer is not provided.
-	ErrAuthorizerNotProvided = clientError{errString: "authorizer function was not provided to client"}
+	// ErrBadConfig is returned from New when an Authorizer is not provided.
+	ErrBadConfig = clientError{errString: "config could not be generated"}
 
-	// ErrTLSConfigRequired is returned when the client attepmts to use a wss:// url without a TLS config
-	// ErrTLSConfigRequired = clientError{errString: "tls config must be provided to use secure connections"}
+	// ErrAuthFailed is returned when authentication with the proxy fails
+	ErrAuthFailed = clientError{errString: "auth failed", auth: true}
 )

--- a/whproxy/proxy.go
+++ b/whproxy/proxy.go
@@ -192,7 +192,7 @@ func (p *proxy) register(w http.ResponseWriter, r *http.Request, id, tokenString
 	// validation does not require lock
 	if err := p.validateJWT(id, tokenString); err != nil {
 		p.logerrorf(id, r.RemoteAddr, "unable to validate token: %v", err)
-		http.Error(w, http.StatusText(400), 400)
+		http.Error(w, http.StatusText(401), 401)
 		return
 	}
 

--- a/whproxy/proxy_test.go
+++ b/whproxy/proxy_test.go
@@ -559,7 +559,7 @@ func TestProxyAuth(t *testing.T) {
 	header.Set("Authorization", "Bearer "+wsworkerjwt)
 
 	conn, res, err := websocket.DefaultDialer.Dial(wsURL+"/register/workerid", header)
-	if res == nil || res.StatusCode != 400 {
+	if res == nil || res.StatusCode != 401 {
 		_ = conn.Close()
 		t.Fatalf("connection should fail")
 	}


### PR DESCRIPTION
Use a Configurer function to generate a config object. This allows clients to dynamically change their ID and Token. Useful for refreshing tokens from tc-auth.