### PR TITLE
Bug 1515531 - stop returning stream ID from session.Open

### DIFF
--- a/whproxy/proxy.go
+++ b/whproxy/proxy.go
@@ -280,13 +280,12 @@ func (p *proxy) serveRequest(w http.ResponseWriter, r *http.Request, id string, 
 	}
 	r.URL = reqURI
 	p.logf(id, r.RemoteAddr, "attempting to open new stream")
-	reqStream, streamID, err := session.Open()
+	reqStream, err := session.Open()
 	if err != nil {
 		p.logerrorf(id, r.RemoteAddr, "could not open stream: path=%s", path)
 		http.Error(w, http.StatusText(500), 500)
 		return
 	}
-	p.logf(id, r.RemoteAddr, "opened new stream: ID=%d", streamID)
 
 	// rewrite path for tunnel and write request
 	err = r.Write(reqStream)

--- a/wsmux/bench_test.go
+++ b/wsmux/bench_test.go
@@ -49,7 +49,7 @@ func echoClientFunc(b *testing.B, client *Session, wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 	hash := sha256.New()
-	str, _, err := client.Open()
+	str, err := client.Open()
 	if err != nil {
 		panic(err)
 	}

--- a/wsmux/http_test.go
+++ b/wsmux/http_test.go
@@ -32,7 +32,7 @@ func TestGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stream, _, err := session.Open()
+	stream, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestPost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stream, _, err := session.Open()
+	stream, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestMultiplePost(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		stream, _, err := session.Open()
+		stream, err := session.Open()
 		if err != nil {
 			panic(err)
 		}
@@ -162,7 +162,7 @@ func TestWebSocket(t *testing.T) {
 	//runtime.Breakpoint()
 	// session.readDeadline = time.Now().Add(10 * time.Second)
 	wsURL := &url.URL{Host: "tcproxy.net", Scheme: "ws"}
-	stream, _, err := session.Open()
+	stream, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wsmux/session_test.go
+++ b/wsmux/session_test.go
@@ -21,7 +21,7 @@ func TestEcho(t *testing.T) {
 	}
 	session := Client(conn, Config{Log: genLogger("echo-test")})
 	// session.readDeadline = time.Now().Add(10 * time.Second)
-	stream, _, err := session.Open()
+	stream, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestEchoLarge(t *testing.T) {
 
 	session := Client(conn, Config{Log: genLogger("echo-large-test")})
 	// session.readDeadline = time.Now().Add(10 * time.Second)
-	stream, _, err := session.Open()
+	stream, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wsmux/stream_test.go
+++ b/wsmux/stream_test.go
@@ -36,7 +36,8 @@ func TestManyStreamEchoLarge(t *testing.T) {
 
 	sender := func(i int) {
 		defer wg.Done()
-		str, id, err := session.Open()
+		str, err := session.Open()
+		id := str.(*stream).id
 		if err != nil {
 			panic(err)
 		}
@@ -57,7 +58,7 @@ func TestManyStreamEchoLarge(t *testing.T) {
 			panic(err)
 		}
 
-		logger.Printf("id: stream %d finished read. msgLen: %d, recvLen: %d", id, len(buf), final.Len())
+		logger.Printf("stream %d finished read. msgLen: %d, recvLen: %d", id, len(buf), final.Len())
 
 		if !bytes.Equal(buf, final.Bytes()) {
 			t.Log(len(buf), final.Len())
@@ -85,7 +86,7 @@ func TestReadDeadlineExpires(t *testing.T) {
 	}
 	client := Client(conn, Config{})
 	errChan := make(chan error, 1)
-	str, _, err := client.Open()
+	str, err := client.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestReadDeadlineReset(t *testing.T) {
 	}
 	client := Client(conn, Config{})
 	errChan := make(chan error, 1)
-	str, _, err := client.Open()
+	str, err := client.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +169,7 @@ func TestWriteDeadline(t *testing.T) {
 	}
 	client := Client(conn, Config{})
 	errChan := make(chan error, 1)
-	str, _, err := client.Open()
+	str, err := client.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +206,7 @@ func TestWriteDeadlineReset(t *testing.T) {
 	}
 	client := Client(conn, Config{})
 	errChan := make(chan error, 1)
-	str, _, err := client.Open()
+	str, err := client.Open()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,7 +263,7 @@ func TestConcurrentReadAndWrite(t *testing.T) {
 	}
 
 	session := Client(conn, Config{Log: genLogger("concurrent-client-test")})
-	str, _, err := session.Open()
+	str, err := session.Open()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This was the only place stream IDs were visible outside of the API.